### PR TITLE
0626 support more scenarios

### DIFF
--- a/iam-policy.json
+++ b/iam-policy.json
@@ -113,7 +113,11 @@
             "Action": [
                 "s3:ListBucket"
             ],
-            "Resource": "arn:aws:s3:::tf-emqx-performance-test*"
+            "Resource": [
+                "arn:aws:s3:::tf-emqx-performance-test",
+                "arn:aws:s3:::tf-emqx-performance-test2",
+                "arn:aws:s3:::id-emqx-test"
+            ]
         },
         {
             "Effect": "Allow",
@@ -139,7 +143,11 @@
                 "s3:PutObjectVersionAcl",
                 "s3:PutObjectVersionTagging"
             ],
-            "Resource": "arn:aws:s3:::tf-emqx-performance-test*/*"
+            "Resource": [
+                "arn:aws:s3:::tf-emqx-performance-test/*",
+                "arn:aws:s3:::tf-emqx-performance-test2/*",
+                "arn:aws:s3:::id-emqx-test/*"
+            ]
         }
     ]
 }

--- a/modules/emqttb/main.tf
+++ b/modules/emqttb/main.tf
@@ -20,5 +20,8 @@ module "emqttb_ec2" {
     s3_bucket_name   = var.s3_bucket_name
     bench_id         = var.bench_id
     scenario         = var.scenario
+    grafana_url      = var.grafana_url
+    start_n_multiplier = var.start_n_multiplier
+    prometheus_push_gw_url = var.prometheus_push_gw_url
   })
 }

--- a/modules/emqttb/templates/user_data.tpl
+++ b/modules/emqttb/templates/user_data.tpl
@@ -15,15 +15,46 @@ sysctl -w net.ipv4.ip_local_port_range='1024 65535'
 sysctl -w net.ipv4.tcp_fin_timeout=5
 
 mkdir emqttb && cd emqttb
-wget "${package_url}" -O /emqttb.tar.gz
+wget "${package_url}" -O ./emqttb.tar.gz
 tar xzf ./emqttb.tar.gz
+
+START_N=$((${start_n_multiplier} * ($TF_LAUNCH_INDEX-1)))
+
+hostnamectl set-hostname "emqttb-$TF_LAUNCH_INDEX"
+
+# wait max 2 min for grafana
+curl --head -X GET --retry 12 --retry-connrefused --retry-delay 10 ${grafana_url}
+
+cat << EOF > /lib/systemd/system/emqttb.service
+[Unit]
+Description=EMQTT bench daemon
+After=network.target
+
+[Service]
+Environment=EMQTTB_METRICS__GRAFANA__LOGIN=admin
+Environment=EMQTTB_METRICS__GRAFANA__PASSWORD=admin
+Environment=EMQTTB_METRICS__GRAFANA__URL=${grafana_url}
+ExecStart=/opt/emqttb/bin/emqttb --grafana --restapi --pushgw --pushgw-url ${prometheus_push_gw_url} ${scenario} @g --host ${emqx_hosts}
+LimitNOFILE=1048576
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
 
 function signal_done() {
   sleep ${test_duration}
+  systemctl stop emqttb.service
+  cp /var/log/cloud-init-output.log /tmp/emqttb.log /var/lib/cloud/instance/user-data.txt ./
+  journalctl -u emqttb.service > emqttb-stdout.log
+  tar czf ./emqttb-$TF_LAUNCH_INDEX.tar.gz cloud-init-output.log emqttb.log emqttb-stdout.log user-data.txt
+  aws s3 cp ./emqttb-$TF_LAUNCH_INDEX.tar.gz s3://${s3_bucket_name}/${bench_id}/emqttb-$TF_LAUNCH_INDEX.tar.gz
   touch EMQTTB_DONE
-  aws s3 cp EMQTTB_DONE s3://${s3_bucket_name}/${bench_id}/EMQTTB_DONE
+  aws s3 cp EMQTTB_DONE s3://${s3_bucket_name}/${bench_id}/EMQTTB_DONE_$TF_LAUNCH_INDEX
 }
 
 signal_done &
 
-bin/emqttb --restapi --log-level error ${scenario} @g --host ${emqx_hosts}
+systemctl enable --now emqttb.service

--- a/modules/emqttb/templates/user_data.tpl
+++ b/modules/emqttb/templates/user_data.tpl
@@ -15,8 +15,8 @@ sysctl -w net.ipv4.ip_local_port_range='1024 65535'
 sysctl -w net.ipv4.tcp_fin_timeout=5
 
 mkdir emqttb && cd emqttb
-wget ${package_url}
-tar xzf ./emqttb*.tar.gz
+wget "${package_url}" -O /emqttb.tar.gz
+tar xzf ./emqttb.tar.gz
 
 function signal_done() {
   sleep ${test_duration}

--- a/modules/emqttb/variables.tf
+++ b/modules/emqttb/variables.tf
@@ -79,3 +79,19 @@ variable "subnet_id" {
   description = "Subnet ID"
   type        = string
 }
+
+variable "start_n_multiplier" {
+  description = "start-n multiplier for each next emqttb instance based on launch index"
+  type        = number
+  default     = 0
+}
+
+variable "grafana_url" {
+  description = "Grafana URL"
+  type        = string
+}
+
+variable "prometheus_push_gw_url" {
+  description = "Prometheus Push Gateway URL"
+  type        = string
+}

--- a/modules/emqx/main.tf
+++ b/modules/emqx/main.tf
@@ -19,10 +19,12 @@ module "emqx_ec2" {
   key_name          = var.key_name
   subnet_id         = var.subnet_id
   extra_user_data   = templatefile("${path.module}/templates/user_data.tpl", {
+    test_duration    = var.test_duration
     s3_bucket_name   = var.s3_bucket_name
     bench_id         = var.bench_id
     package_url      = var.package_url
     cluster_dns_name = local.cluster_dns_name
+    prometheus_push_gw_url = var.prometheus_push_gw_url
   })
 
 }

--- a/modules/emqx/variables.tf
+++ b/modules/emqx/variables.tf
@@ -28,6 +28,11 @@ variable "route53_zone_id" {
   type        = string
 }
 
+variable "test_duration" {
+  description = "Performance test duration"
+  type        = string
+}
+
 variable "instance_count" {
   description = "Instance count"
   type        = number
@@ -62,5 +67,10 @@ variable "key_name" {
 
 variable "subnet_id" {
   description = "Subnet ID"
+  type        = string
+}
+
+variable "prometheus_push_gw_url" {
+  description = "Prometheus Push Gateway URL"
   type        = string
 }

--- a/modules/prometheus/outputs.tf
+++ b/modules/prometheus/outputs.tf
@@ -11,3 +11,11 @@ output "public_ip" {
 output "instance_id" {
   value = module.prometheus_ec2.instance_id
 }
+
+output "push_gw_url" {
+  value = "http://${module.prometheus_ec2.private_ip[0]}:9091"
+}
+
+output "grafana_url" {
+  value = "http://${module.prometheus_ec2.private_ip[0]}:3000"
+}

--- a/monitoring/user_data.sh.tpl
+++ b/monitoring/user_data.sh.tpl
@@ -135,13 +135,11 @@ mkdir -p /var/lib/grafana/dashboards
 chown grafana:grafana /var/lib/grafana/dashboards
 # emqx
 wget https://grafana.com/api/dashboards/17446/revisions/1/download -O /tmp/17446.json
-# node exporter full
-wget https://grafana.com/api/dashboards/1860/revisions/31/download -O /tmp/1860.json
 export DS_PROMETHEUS=Prometheus
 envsubst < /tmp/17446.json > /var/lib/grafana/dashboards/17446.json
-envsubst < /tmp/1860.json > /var/lib/grafana/dashboards/1860.json
 sed -i 's/DS_PROMETHEUS/Prometheus/g' /var/lib/grafana/dashboards/17446.json
-sed -i 's/DS_PROMETHEUS/Prometheus/g' /var/lib/grafana/dashboards/1860.json
+# node exporter full
+wget https://grafana.com/api/dashboards/1860/revisions/31/download -O /var/lib/grafana/dashboards/1860.json
 
 mkdir /etc/systemd/system/grafana-server.service.d
 cat << EOF > /etc/systemd/system/grafana-server.service.d/override.conf

--- a/run-1m-conns.sh
+++ b/run-1m-conns.sh
@@ -7,30 +7,29 @@ set -euo pipefail
 
 # Script arguments are optional, but the order is fixed.
 
-export TF_VAR_region="${1:-eu-north-1}"
-export TF_VAR_s3_bucket_name="${2:-tf-emqx-performance-test}"
-export TF_VAR_bench_id="${3:-$(date +%Y-%m-%d-%H-%M-%S)/1m-conns}"
-
 EMQX_VERSION=5.1.0
 wget -nc https://github.com/emqx/emqx/releases/download/v$EMQX_VERSION/emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
 export TF_VAR_package_file=emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
 
+export TF_VAR_region="${1:-eu-central-1}"
+export TF_VAR_s3_bucket_name="${2:-id-emqx-test}"
+export TF_VAR_bench_id="${3:-$(date +%Y-%m-%d)/1m-conns}"
 export TF_VAR_test_duration=3600
+export TF_VAR_emqx_instance_type=c5.2xlarge
+export TF_VAR_emqx_instance_count=3
 
 export TF_VAR_use_emqttb=1
 export TF_VAR_emqttb_instance_count=5
 export TF_VAR_emqttb_instance_type=c5.2xlarge
 export TF_VAR_emqttb_scenario="@conn -N 200_000 --conninterval 1ms @a -a conn_group_autoscale -V 100"
 
-# export TF_VAR_use_emqtt_bench=0
+export TF_VAR_use_emqtt_bench=0
 # export TF_VAR_emqtt_bench_instance_count=5
 # export TF_VAR_emqtt_bench_instance_type="c5.2xlarge"
 # export TF_VAR_emqtt_bench_scenario="conn -c 200000 -i 10"
 
-export TF_VAR_emqx_instance_count=3
-export TF_VAR_emqx_instance_type="c5.2xlarge"
-export TF_VAR_internal_mqtt_nlb_count=1
-export TF_VAR_public_mqtt_nlb=0
+# export TF_VAR_internal_mqtt_nlb_count=1
+# export TF_VAR_public_mqtt_nlb=0
 
 terraform init
 terraform apply

--- a/run-1m-conns.sh
+++ b/run-1m-conns.sh
@@ -11,7 +11,7 @@ export TF_VAR_region="${1:-eu-north-1}"
 export TF_VAR_s3_bucket_name="${2:-tf-emqx-performance-test}"
 export TF_VAR_bench_id="${3:-$(date +%Y-%m-%d-%H-%M-%S)/1m-conns}"
 
-EMQX_VERSION=5.0.25
+EMQX_VERSION=5.1.0
 wget -nc https://github.com/emqx/emqx/releases/download/v$EMQX_VERSION/emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
 export TF_VAR_package_file=emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
 

--- a/run-1on1.sh
+++ b/run-1on1.sh
@@ -2,17 +2,19 @@
 
 set -euo pipefail
 
-EMQX_VERSION=5.1.0
+# 50k publishers, 50k subscribers, 50k topics
+# QoS 1, payload 16B
+
+EMQX_VERSION=${EMQX_VERSION:-5.1.0}
 wget -nc https://github.com/emqx/emqx/releases/download/v$EMQX_VERSION/emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
 export TF_VAR_package_file=emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
 
-export TF_VAR_region=eu-central-1
-export TF_VAR_s3_bucket_name=id-emqx-test
-export TF_VAR_bench_id="$(date +%Y-%m-%d)"
+export TF_VAR_region="${1:-eu-central-1}"
+export TF_VAR_s3_bucket_name="${2:-id-emqx-test}"
+export TF_VAR_bench_id="${3:-$(date +%Y-%m-%d)/1on1}"
 export TF_VAR_test_duration=3600
 export TF_VAR_emqx_instance_type=c5.2xlarge
 export TF_VAR_emqx_instance_count=3
-export TF_VAR_package_file=emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
 
 export TF_VAR_use_emqttb=1
 export TF_VAR_emqttb_instance_count=1

--- a/run-fanin.sh
+++ b/run-fanin.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# 50k publishers, 50k pub topics
+# pub rate: 50k/s (each publisher pubs a message per second)
+# use a shared subscription to consume data (to avoid slow consumption by subscribers affecting broker performance, 500 subscribers are used to share the subscription)
+# shared subscription’s topic: $share/perf/test/#
+# pub topics: test/$clientid
+# QoS 1, payload 16B
+
+EMQX_VERSION=${EMQX_VERSION:-5.1.0}
+wget -nc https://github.com/emqx/emqx/releases/download/v$EMQX_VERSION/emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
+export TF_VAR_package_file=emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
+
+export TF_VAR_region="${1:-eu-central-1}"
+export TF_VAR_s3_bucket_name="${2:-id-emqx-test}"
+export TF_VAR_bench_id="${3:-$(date +%Y-%m-%d)/fanin}"
+export TF_VAR_test_duration=3600
+export TF_VAR_emqx_instance_type=c5.2xlarge
+export TF_VAR_emqx_instance_count=3
+
+export TF_VAR_use_emqttb=1
+export TF_VAR_emqttb_instance_count=2
+export TF_VAR_emqttb_start_n_multiplier=25000
+export TF_VAR_emqttb_instance_type=c5.xlarge
+export TF_VAR_emqttb_scenario='@pub --topic t/%n --conninterval 10ms --pubinterval 1s --num-clients 25_000 --start-n $START_N --size 16 @sub --topic \$share/perf/t/# --conninterval 10ms --num-clients 250'
+
+export TF_VAR_use_emqtt_bench=0
+# export TF_VAR_emqtt_bench_instance_count=1
+# export TF_VAR_emqtt_bench_instance_type=c5.large
+# export TF_VAR_emqtt_bench_scenario="conn -c 100000 -i 10"
+
+terraform init
+terraform apply
+read -p "Press Enter to continue" key
+terraform destroy

--- a/run-fanout.sh
+++ b/run-fanout.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# 5 publishers, 5 topics, 1000 subscribers (each sub to all topics)
+# pub rate: 250/s, so sub rate = 250*1000 = 250k/s
+# QoS 1, payload 16B
+
+EMQX_VERSION=${EMQX_VERSION:-5.1.0}
+wget -nc https://github.com/emqx/emqx/releases/download/v$EMQX_VERSION/emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
+export TF_VAR_package_file=emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
+
+export TF_VAR_region="${1:-eu-central-1}"
+export TF_VAR_s3_bucket_name="${2:-id-emqx-test}"
+export TF_VAR_bench_id="${3:-$(date +%Y-%m-%d)/fanout}"
+export TF_VAR_test_duration=3600
+export TF_VAR_emqx_instance_type=c5.large
+export TF_VAR_emqx_instance_count=3
+
+export TF_VAR_use_emqttb=1
+export TF_VAR_emqttb_instance_count=1
+export TF_VAR_emqttb_instance_type=c5.2xlarge
+export TF_VAR_emqttb_scenario="@pub --topic 't/%n' --conninterval 10ms --pubinterval 20ms --num-clients 5 --size 16 @sub --topic 't/#' --conninterval 10ms --num-clients 1000"
+
+export TF_VAR_use_emqtt_bench=0
+# export TF_VAR_emqtt_bench_instance_count=1
+# export TF_VAR_emqtt_bench_instance_type=c5.large
+# export TF_VAR_emqtt_bench_scenario="conn -c 100000 -i 10"
+
+terraform init
+terraform apply
+read -p "Press Enter to continue" key
+terraform destroy

--- a/run-long.sh
+++ b/run-long.sh
@@ -2,25 +2,24 @@
 
 set -euo pipefail
 
-EMQX_VERSION=5.0.25
+EMQX_VERSION=5.1.0
 wget -nc https://github.com/emqx/emqx/releases/download/v$EMQX_VERSION/emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
 export TF_VAR_package_file=emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
 
 export TF_VAR_region=eu-central-1
 export TF_VAR_s3_bucket_name=id-emqx-test
-export TF_VAR_bench_id="$(date +%Y-%m-%d-%H-%M-%S)"
+export TF_VAR_bench_id="$(date +%Y-%m-%d)"
 export TF_VAR_test_duration=3600
-export TF_VAR_emqx_instance_type=c5.large
+export TF_VAR_emqx_instance_type=c5.2xlarge
 export TF_VAR_emqx_instance_count=3
 export TF_VAR_package_file=emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
-export TF_VAR_internal_mqtt_nlb_count=3
 
 export TF_VAR_use_emqttb=1
 export TF_VAR_emqttb_instance_count=1
-export TF_VAR_emqttb_instance_type=c5.large
-# export TF_VAR_emqttb_scenario="@pubsub_fwd -n 50_000 --pub-qos 1 --sub-qos 1"
+export TF_VAR_emqttb_instance_type=c5.2xlarge
+export TF_VAR_emqttb_scenario="@pubsub_fwd -n 50_000 --pub-qos 1 --sub-qos 1"
 
-# export TF_VAR_use_emqtt_bench=0
+export TF_VAR_use_emqtt_bench=0
 # export TF_VAR_emqtt_bench_instance_count=1
 # export TF_VAR_emqtt_bench_instance_type=c5.large
 # export TF_VAR_emqtt_bench_scenario="conn -c 100000 -i 10"

--- a/run.sh
+++ b/run.sh
@@ -9,16 +9,16 @@ set -euo pipefail
 
 export TF_VAR_region="${1:-eu-west-1}"
 export TF_VAR_s3_bucket_name="${2:-tf-emqx-performance-test2}"
-export TF_VAR_bench_id="${3:-$(date +%Y-%m-%d-%H-%M-%S)}"
-export TF_VAR_test_duration="${4:-600}"
+export TF_VAR_bench_id="${3:-$(date +%Y-%m-%d)}"
+export TF_VAR_test_duration="${4:-3600}"
 
-export TF_VAR_emqx_instance_type="c5.xlarge"
-export TF_VAR_emqx_instance_count=3
-export TF_VAR_emqttb_instance_type="c5.2xlarge"
+export TF_VAR_emqx_instance_type="c5.large"
+export TF_VAR_emqx_instance_count=1
+export TF_VAR_emqttb_instance_type="c5.large"
 export TF_VAR_emqttb_instance_count=1
-export TF_VAR_emqttb_scenario="@pubsub_fwd -n 50_000 --pub-qos 1 --sub-qos 1"
+export TF_VAR_emqttb_scenario="@pubsub_fwd -n 5_000 --pub-qos 1 --sub-qos 1"
 
-EMQX_VERSION=5.0.26
+EMQX_VERSION=5.1.0
 wget -nc https://github.com/emqx/emqx/releases/download/v$EMQX_VERSION/emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
 export TF_VAR_package_file=emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
 

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 
 # Script arguments are optional, but the order is fixed.
 
+EMQX_VERSION=${EMQX_VERSION:-5.1.0}
+wget -nc https://github.com/emqx/emqx/releases/download/v$EMQX_VERSION/emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
+export TF_VAR_package_file=emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
+
 export TF_VAR_region="${1:-eu-west-1}"
 export TF_VAR_s3_bucket_name="${2:-tf-emqx-performance-test2}"
 export TF_VAR_bench_id="${3:-$(date +%Y-%m-%d)}"
@@ -17,10 +21,6 @@ export TF_VAR_emqx_instance_count=1
 export TF_VAR_emqttb_instance_type="c5.large"
 export TF_VAR_emqttb_instance_count=1
 export TF_VAR_emqttb_scenario="@pubsub_fwd -n 5_000 --pub-qos 1 --sub-qos 1"
-
-EMQX_VERSION=5.1.0
-wget -nc https://github.com/emqx/emqx/releases/download/v$EMQX_VERSION/emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
-export TF_VAR_package_file=emqx-$EMQX_VERSION-ubuntu20.04-amd64.deb
 
 terraform init
 terraform apply

--- a/variables.tf
+++ b/variables.tf
@@ -69,6 +69,18 @@ variable "emqttb_scenario" {
   default     = "@pubsub_fwd -n 1_000 --pub-qos 1 --sub-qos 1"
 }
 
+variable "emqttb_start_n_multiplier" {
+  description = "start-n multiplier for each next emqttb instance based on launch index"
+  type        = number
+  default     = 0
+}
+
+variable "use_emqttb" {
+  description = "Whether to use emqttb to generate load"
+  type        = number
+  default     = 1
+}
+
 variable "route53_zone_name" {
   description = "Hosted zone name"
   type        = string
@@ -91,12 +103,6 @@ variable "create_public_mqtt_nlb" {
   description = "Whether to create publicly exposed MQTT NLB on 1883"
   type        = number
   default     = 0
-}
-
-variable "use_emqttb" {
-  description = "Whether to use emqttb to generate load"
-  type        = number
-  default     = 1
 }
 
 variable "use_emqtt_bench" {
@@ -145,4 +151,3 @@ variable "prometheus_remote_write_region" {
   type        = string
   default     = "eu-west-1"
 }
-


### PR DESCRIPTION
- Support all required scenarios
- Support several emqttb instances
- Upload emqttb and emqx logs when test duration expired
- Switch back to use prometheus push gateway instead of scraping
- Fix grafana dashboard issue
- Start emqttb as systemd service