### PR TITLE
fix: resolve key name conflict

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -167,7 +167,7 @@ resource "aws_key_pair" "kp" {
 }
 
 resource "aws_key_pair" "kp2" {
-  key_name   = local.ssh_key_name
+  key_name   = "${local.ssh_key_name}-2"
   public_key = tls_private_key.pk.public_key_openssh
   provider   = aws.secondary
 }


### PR DESCRIPTION
Fixes error occurring in single origin deployment:
```
╷
│ Error: importing EC2 Key Pair (perftest-2023-10-06/serhii-otel): InvalidKeyPair.Duplicate: The keypair already exists
│ 	status code: 400, request id: 958ef73c-e00a-4d61-90df-ee6bafac87da
│ 
│   with aws_key_pair.kp,
│   on main.tf line 164, in resource "aws_key_pair" "kp":
│  164: resource "aws_key_pair" "kp" {
│ 
╵
```