### PR TITLE
fix: change prometheus snapshot compression to gz

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ preserving permissions:
 
 ```sh
 cd prometheus_snapshots
-tar -xvpf 20241007T164452Z-11cc51d6d14856dd.tar.bz2
+tar -xvpf 20241007T164452Z-11cc51d6d14856dd.tar.gz
 ```
 
 It contains a docker compose manifest that spins up grafana and prometheus to serve

--- a/ansible/roles/prometheus_snapshot/tasks/main.yml
+++ b/ansible/roles/prometheus_snapshot/tasks/main.yml
@@ -76,8 +76,8 @@
 - name: Archive snapshot
   community.general.archive:
     path: "{{ stage_dir }}"
-    dest: "/opt/monitoring/{{ _snapshot_res.json.data.name }}.tar.bz2"
-    format: bz2
+    dest: "/opt/monitoring/{{ _snapshot_res.json.data.name }}.tar.gz"
+    format: gz
 
 - name: Create local snapshot dir
   ansible.builtin.file:
@@ -87,8 +87,8 @@
 
 - name: Fetch snapshot
   ansible.builtin.fetch:
-    src: "/opt/monitoring/{{ _snapshot_res.json.data.name }}.tar.bz2"
-    dest: "../prometheus_snapshots/{{ _snapshot_res.json.data.name }}.tar.bz2"
+    src: "/opt/monitoring/{{ _snapshot_res.json.data.name }}.tar.gz"
+    dest: "../prometheus_snapshots/{{ _snapshot_res.json.data.name }}.tar.gz"
     flat: true
 
 - name: Remove temporary stage


### PR DESCRIPTION
Github doesn't accept `.bz2` files as uploads, but accepts `.gz`...

So we change the default type here so that it's easier to share via pull requests.