### PR TITLE
fix: disable `vm_dist` prometheus collector in `emqx.conf`

### DIFF
--- a/ansible/roles/emqx5/templates/emqx.conf.j2
+++ b/ansible/roles/emqx5/templates/emqx.conf.j2
@@ -53,8 +53,8 @@ prometheus {
   collectors {
     mnesia = disabled
     vm_msacc = disabled
+    vm_dist = disabled
 {% if emqx_prometheus_collectors_enabled %}
-    vm_dist = enabled
     vm_memory = enabled
     vm_statistics = enabled
     vm_system_info = enabled


### PR DESCRIPTION
It enables `prometheus_vm_dist_collector` collector that has terribly poor scaling depending on number of open ports (e.g. connections), spending a lot of CPU and thereby skewing performance-related metrics.